### PR TITLE
Hotfix: downgrade chalk version

### DIFF
--- a/.github/workflows/limetest.yml
+++ b/.github/workflows/limetest.yml
@@ -1,0 +1,40 @@
+name: Limetest Example Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    # Manual trigger
+
+jobs:
+  run-limetest-cli:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js 18
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 10.10.0
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Build packages
+      run: pnpm run build
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chrome
+
+    - name: Run Limetest
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: npx limetest examples/example.spec.md 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limtest-monorepo",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Limetest Testing Framework Monorepo",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limetest/core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Core Playwright automation library for Best testing framework",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/limetest/package.json
+++ b/packages/limetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limetest/limetest",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Litest testing framework and cli",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/limetest/package.json
+++ b/packages/limetest/package.json
@@ -15,7 +15,7 @@
     "@modelcontextprotocol/sdk": "^1.6.1",
     "ai": "^4.3.10",
     "axios": "^1.9.0",
-    "chalk": "^5.4.1",
+    "chalk": "^4.1.2",
     "commander": "^13.1.0",
     "dotenv": "^16.4.7",
     "glob": "10.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limetest/mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Litest testing framework MCP Server",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       chalk:
-        specifier: ^5.4.1
-        version: 5.4.1
+        specifier: ^4.1.2
+        version: 4.1.2
       commander:
         specifier: ^13.1.0
         version: 13.1.0


### PR DESCRIPTION
Downgrade `chalk` version to `4.1.2` to be compatible with Linux env